### PR TITLE
Allow make_savable to work with ridgeRF

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: forestry
 Type: Package
 Title: Forestry
-Version: 0.8.0.0
+Version: 0.8.0.1
 Author: Sören Künzel, Edward Liu, Theo Saarinen, Allen Tang, Jasjeet Sekhon
 Maintainer: Sören Künzel <srk@berkeley.edu>
 Description: Gradient Boosting, Random Forests, Tree Estimators, Optimal Trees,

--- a/src/forestry.cpp
+++ b/src/forestry.cpp
@@ -309,7 +309,6 @@ std::unique_ptr< std::vector<float> > forestry::predict(
   for (size_t j=0; j<numObservations; j++) {
     prediction.push_back(0);
   }
-
   #if DOPARELLEL
   size_t nthreadToUse = getNthread();
   if (getNthread() == 0) {
@@ -665,6 +664,8 @@ void forestry::reconstructTrees(
                 getMinNodeSizeToSplitSpt(),
                 getMinNodeSizeToSplitAvg(),
                 getMaxDepth(),
+                getRidgeRF(),
+                getOverfitPenalty(),
                 (*categoricalFeatureColsRcpp),
                 (*var_ids)[i],
                 (*split_vals)[i],

--- a/src/forestry.cpp
+++ b/src/forestry.cpp
@@ -309,6 +309,7 @@ std::unique_ptr< std::vector<float> > forestry::predict(
   for (size_t j=0; j<numObservations; j++) {
     prediction.push_back(0);
   }
+
   #if DOPARELLEL
   size_t nthreadToUse = getNthread();
   if (getNthread() == 0) {

--- a/src/forestryTree.cpp
+++ b/src/forestryTree.cpp
@@ -1979,13 +1979,15 @@ std::unique_ptr<tree_info> forestryTree::getTreeInfo(
   return treeInfo;
 }
 
-void forestryTree::reconstruct_tree(
+void forestryTree:: reconstruct_tree(
     size_t mtry,
     size_t minNodeSizeSpt,
     size_t minNodeSizeAvg,
     size_t minNodeSizeToSplitSpt,
     size_t minNodeSizeToSplitAvg,
     size_t maxDepth,
+    bool ridgeRF,
+    float overfitPenalty,
     std::vector<size_t> categoricalFeatureColsRcpp,
     std::vector<int> var_ids,
     std::vector<double> split_vals,
@@ -2001,6 +2003,8 @@ void forestryTree::reconstruct_tree(
   _minNodeSizeToSplitSpt = minNodeSizeToSplitSpt;
   _minNodeSizeToSplitAvg = minNodeSizeToSplitAvg;
   _maxDepth = maxDepth;
+  _ridgeRF = ridgeRF;
+  _overfitPenalty = overfitPenalty;
 
   _averagingSampleIndex = std::unique_ptr< std::vector<size_t> > (
     new std::vector<size_t>

--- a/src/forestryTree.cpp
+++ b/src/forestryTree.cpp
@@ -1979,7 +1979,7 @@ std::unique_ptr<tree_info> forestryTree::getTreeInfo(
   return treeInfo;
 }
 
-void forestryTree:: reconstruct_tree(
+void forestryTree::reconstruct_tree(
     size_t mtry,
     size_t minNodeSizeSpt,
     size_t minNodeSizeAvg,

--- a/src/forestryTree.h
+++ b/src/forestryTree.h
@@ -66,6 +66,8 @@ public:
       size_t minNodeSizeToSplitSpt,
       size_t minNodeSizeToSplitAvg,
       size_t maxDepth,
+      bool ridgeRF,
+      float overfitPenalty,
       std::vector<size_t> categoricalFeatureColsRcpp,
       std::vector<int> var_ids,
       std::vector<double> split_vals,
@@ -204,6 +206,7 @@ private:
   std::unique_ptr< std::vector<size_t> > _averagingSampleIndex;
   std::unique_ptr< std::vector<size_t> > _splittingSampleIndex;
   std::unique_ptr< RFNode > _root;
+  bool _ridgeRF;
   float _overfitPenalty;
   std::vector<double>* _benchmark;
 };

--- a/src/rcpp_cppBuildInterface.cpp
+++ b/src/rcpp_cppBuildInterface.cpp
@@ -699,7 +699,7 @@ Rcpp::List rcpp_reconstructree(
     (bool) middleSplit,
     (int) maxObs,
     (bool) ridgeRF,
-    (double) overfitPenalty,
+    (float) overfitPenalty,
     doubleTree
   );
 


### PR DESCRIPTION
Forestry objects with parameter "ridgeRF=TRUE" and a corresponding overfitPenalty can now be saved.